### PR TITLE
Fix: Modal mobile height fix

### DIFF
--- a/src/styles/Modal/index.scss
+++ b/src/styles/Modal/index.scss
@@ -1,7 +1,7 @@
 
 .modal-cover {
-    width: 100vw;
-    height: 100vh;
+    width: 100%;
+    height: 100%;
     background: transparent;
     position: fixed;
     top: 0px;
@@ -83,7 +83,7 @@
 
         .modal-list {
             width: 100%;
-            height: 100%;
+            height: auto;
         }
     }
 
@@ -95,8 +95,9 @@
             border-top: 2px solid rgba(0,0,0,0.30);
             border-bottom: 2px solid rgba(0,0,0,0.30);
             border-radius: 0px;
+            height: 50px;
             &.modal-mounted {
-                height: 100%;
+                height: calc(100% - 120px);
             }
             &.modal-unmount {
                 height: 50px


### PR DESCRIPTION
Modal height would go past screen on the bottom, due to setting the modal height to 100% on mobile but not taking into account the top margin added on the parent div.
